### PR TITLE
added hint property for column header

### DIFF
--- a/examples/simple-column-config.html
+++ b/examples/simple-column-config.html
@@ -33,8 +33,8 @@
   var table = grid.createGrid()
           .columns(
             [
-              { key: 'name', locked: 'left', width: 200 }
-            , { key: 'email', sortDescending: true }
+              { key: 'name', locked: 'left', width: 200, hint: 'custom hint on user column' }
+            , { key: 'email', sortDescending: true, hint: '' }
             , { key: 'phone', locked: 'right' }
             , { key: 'username', className: 'fancy-plus fancy-cell' }
             , {

--- a/man/column-configuration.md
+++ b/man/column-configuration.md
@@ -37,6 +37,28 @@ const columns = [
   ...
 ```
 
+#### Column header hints
+
+  You can specify a `hint` string for the label on the column header.
+  If the `hint` field is not provided, the `label` will be used instead, if `label` is not provided, `key` will be used
+  If `hint` is specified as empty string then hint will not be displayed
+
+```javascript
+const columns = [
+  {
+    key: "bid"
+  , label: "Bid Price"
+  , hint: "Bid Price long descripion"
+  },
+  {
+    key: "bidName"
+  , label: "Bid Name"
+  , hint: ""
+  }
+  ...
+```
+
+
 #### Hidden columns
 
 Columns can be hidden or shown using the default column selector.

--- a/src/headers.js
+++ b/src/headers.js
@@ -1,6 +1,6 @@
 import { functor, property } from '@zambezi/fun'
 import { headerBlockLayout } from './header-block-layout'
-import { isNumber, isString } from 'underscore'
+import { isNumber, isString, isUndefined } from 'underscore'
 import { select } from 'd3-selection'
 import { selectionChanged, appendFromTemplate } from '@zambezi/d3-utils'
 
@@ -75,7 +75,7 @@ export function createHeaders () {
         .style('left', offset)
       .select('.cell-text')
         .text(labelOrKey)
-        .attr('title', labelOrKey)
+        .attr('title', hintOrLabelOrKey)
   }
 
   function updateBlock (s) {
@@ -131,6 +131,10 @@ function scrollLeftDefined (d) {
 
 function labelOrKey (d) {
   return isString(d.label) ? d.label : d.key
+}
+
+function hintOrLabelOrKey (d) {
+  return (isUndefined(d.hint) ? (isString(d.label) ? d.label : d.key) : d.hint)
 }
 
 function children (d) {


### PR DESCRIPTION
Added Hint property for the column header

## Description
Added Hint property to cover cases:

![image](https://user-images.githubusercontent.com/6177936/34961672-ee66a9fc-fa48-11e7-8f4f-780f0c3d003e.png)

## Motivation and Context

1. When we want to have longer description for header
2. When we dont need to see the hint

## How Was This Tested?
Updated simple-column-config.html and checked manually the cases when provide custom hint and we don;t provide it and hint is not displayd  


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change follows the style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
